### PR TITLE
Fix BuildSQLWhere for empty fields

### DIFF
--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -149,7 +149,7 @@ func BuildSQLSelectFields(table string, fields []string) string {
 // BuildSQLWhere builds and returns a query WHERE of postgres and its arguments
 func BuildSQLWhere(fields models.Fields) (string, []interface{}) {
 	if fields.IsEmpty() {
-		return ErrFieldsAreEmpty, nil
+		return "", nil
 	}
 
 	query := bytes.Buffer{}

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -161,7 +161,7 @@ func TestBuildSQLWhere(t *testing.T) {
 		{
 			name:      "where with emtpy fields",
 			fields:    models.Fields{},
-			wantQuery: ErrFieldsAreEmpty,
+			wantQuery: "",
 			wantArgs:  nil,
 		},
 		{


### PR DESCRIPTION
When we send a `BuildSQLWhere` without fields, we don't need return an error.